### PR TITLE
Some documentation updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ defmodule MyXDR
 end
 
 # using the predefined types in our code
-{:ok, student_b} = MyXDR.build_value!("Student",
+{:ok, student_b} = MyXDR.build_value("Student",
   name: "Student B",
   quiz_scores: [93, 60, 88, 100, 84],
   homework_scores: [80, 100, 99, 0, 90]

--- a/lib/xdr/base.ex
+++ b/lib/xdr/base.ex
@@ -44,47 +44,142 @@ defmodule XDR.Base do
   @doc false
   defmacro __before_compile__(_env) do
     quote do
+      @doc """
+      Encode an XDR value struct into its binary representation.
+      See `XDR.encode/1` for more details.
+      """
+      @spec encode(XDR.Type.t()) :: {:ok, binary()} | {:error, any()}
       defdelegate encode(type_with_value), to: XDR
+
+      @doc """
+      Like `encode/1`, but returns binary on success instead of a tuple, and raises on failure.
+      See `XDR.encode!/1` for more details.
+      """
+      @spec encode!(XDR.Type.t()) :: binary()
       defdelegate encode!(type_with_value), to: XDR
+
+      @doc """
+      XDR data structures created from `build_value/2` and `decode/2` include
+      lots of type metadata, and the different types don't always store their inner
+      state in the same way. `extract_value/1` acts as a uniform way to pull
+      out the underlying values as native elixir types.
+      See `XDR.extract_value/1` for more details.
+      """
+      @spec extract_value(XDR.Type.t()) :: {:ok | :error, any()}
       defdelegate extract_value(type_with_value), to: XDR
+
+      @doc """
+      Like `extract_value/1`, but returns an XDR type success instead of a tuple, and raises on failure.
+      See `XDR.extract_value!/1` for more details.
+      """
+      @spec extract_value!(XDR.Type.t()) :: any()
       defdelegate extract_value!(type_with_value), to: XDR
 
+      @doc """
+      Get a map of all custom types defined for this module, keyed by the type name
+
+          iex> defmodule CustomXDR do
+          ...>   use XDR.Base
+          ...>   define_type("Name", VariableOpaque)
+          ...>   define_type("Number", Int)
+          ...> end
+          ...> CustomXDR.custom_types()
+          %{
+            "Name" => %XDR.Type.VariableOpaque{},
+            "Number" => %XDR.Type.Int{}
+          }
+      """
+      @spec custom_types() :: map()
       def custom_types() do
         @custom_types
       end
 
+      @doc """
+      Like `resolve_type/1`, but returns an XDR type on success instead of a tuple, and raises on failure.
+      """
+      @spec resolve_type!(XDR.Type.t()) :: XDR.Type.t()
       def resolve_type!(name_or_type) do
         XDR.Type.resolve_type!(name_or_type, custom_types())
       end
 
+      @doc """
+      Resolves the type (and any child types) by replacing custom type names
+      with concrete XDR types specified with `define_type`.
+
+          iex> defmodule ResolveXDR do
+          ...>   use XDR.Base
+          ...>   define_type("Name", VariableOpaque)
+          ...> end
+          ...> ResolveXDR.resolve_type("Name")
+          {:ok, %XDR.Type.VariableOpaque{type_name: "Name", value: nil}}
+      """
+      @spec resolve_type(XDR.Type.t()) :: {:ok, XDR.Type.t()} | {:error, any()}
       def resolve_type(name_or_type) do
         {:ok, XDR.Type.resolve_type!(name_or_type, custom_types())}
       rescue
         error -> {:error, error}
       end
 
+      @doc """
+      Like `build_value/2`, but returns an XDR type on success instead of a tuple, and raises on failure.
+      See `XDR.build_value!/2` for more details.
+      """
+      @spec build_value!(XDR.Type.t(), any()) :: XDR.Type.t()
       def build_value!(name_or_type, value) do
         type = resolve_type!(name_or_type)
         XDR.build_value!(type, value)
       end
 
+      @doc """
+      To build a concrete value, supply the type or custom type name and a value appropriate
+      to that type's definition.
+      See `XDR.build_value/2` for more details.
+      """
+      @spec build_value(XDR.Type.t(), any()) :: {:ok, XDR.Type.t()} | {:error, any()}
       def build_value(name_or_type, value) do
         {:ok, build_value!(name_or_type, value)}
       rescue
         error -> {:error, error}
       end
 
+      @doc """
+      Decode a binary representation into an XDR type with value. Since the binary
+      representation does not contain type info itself, the type or type name is
+      the first parameter.
+      See `XDR.decode!/2` for more details.
+      """
+      @spec decode!(XDR.Type.t(), binary()) :: XDR.Type.t()
       def decode!(name_or_type, encoded) do
         type = resolve_type!(name_or_type)
         XDR.decode!(type, encoded)
       end
 
+      @doc """
+      Decode a binary representation into an XDR type with value. Since the binary
+      representation does not contain type info itself, the type or type name is
+      the first parameter.
+      See `XDR.decode/2` for more details.
+      """
+      @spec decode(XDR.Type.t(), binary()) :: {:ok, XDR.Type.t()} | {:error, any()}
       def decode(name_or_type, encoded) do
         {:ok, decode!(name_or_type, encoded)}
       rescue
         error -> {:error, error}
       end
 
+      @doc """
+      Resolve the reference to a named constant.
+
+          iex> defmodule ConstXDR do
+          ...>   use XDR.Base
+          ...>   define_type("PI", Const, 3.14)
+          ...>   define_type("float", Float)
+          ...> end
+          ...> val = ConstXDR.build_value!("float", ConstXDR.const("PI"))
+          ...> ConstXDR.extract_value!(val)
+          3.14
+      """
+      @spec const(binary()) :: any()
       def const(name) do
         resolve_type!(name)
       end
@@ -118,8 +213,11 @@ defmodule XDR.Base do
   end
 
   @doc """
-  Convenience function to build an XDR type. See `XDR.build_type/2`
+  Convenience function to build an XDR type, allowing the use of custom defined type names.
+
+  See `XDR.build_type/2`
   """
+  @spec build_type(atom(), any()) :: XDR.Type.t()
   def build_type(type, options \\ []) do
     XDR.build_type(type, options)
   end

--- a/lib/xdr/base.ex
+++ b/lib/xdr/base.ex
@@ -1,11 +1,13 @@
 defmodule XDR.Base do
   @moduledoc """
-  Provides the ability to predefine and precompile specific XDR types for your application.
+  Provides the ability to predefine and precompile specific XDR types for your
+  application.
 
   Create a module in your app, and `use XDR.Base`.
 
-  Your module will now have access to the `define_type` macro, as well as all of the
-  functions on the main `XDR` module. See [the README](readme.html#custom-xdr-type-definitions) for an example.
+  Your module will now have access to the `define_type` macro, as well as all
+  of the functions on the main `XDR` module.
+  See [the README](readme.html#custom-xdr-type-definitions) for an example.
 
   """
 
@@ -52,7 +54,8 @@ defmodule XDR.Base do
       defdelegate encode(type_with_value), to: XDR
 
       @doc """
-      Like `encode/1`, but returns binary on success instead of a tuple, and raises on failure.
+      Like `encode/1`, but returns binary on success instead of a tuple,
+      and raises on failure.
       See `XDR.encode!/1` for more details.
       """
       @spec encode!(XDR.Type.t()) :: binary()
@@ -60,8 +63,8 @@ defmodule XDR.Base do
 
       @doc """
       XDR data structures created from `build_value/2` and `decode/2` include
-      lots of type metadata, and the different types don't always store their inner
-      state in the same way. `extract_value/1` acts as a uniform way to pull
+      lots of type metadata, and the different types don't always store their
+      inner state in the same way. `extract_value/1` acts as a uniform way to pull
       out the underlying values as native elixir types.
       See `XDR.extract_value/1` for more details.
       """
@@ -69,7 +72,8 @@ defmodule XDR.Base do
       defdelegate extract_value(type_with_value), to: XDR
 
       @doc """
-      Like `extract_value/1`, but returns an XDR type success instead of a tuple, and raises on failure.
+      Like `extract_value/1`, but returns an XDR type success instead of a
+      tuple, and raises on failure.
       See `XDR.extract_value!/1` for more details.
       """
       @spec extract_value!(XDR.Type.t()) :: any()
@@ -95,7 +99,8 @@ defmodule XDR.Base do
       end
 
       @doc """
-      Like `resolve_type/1`, but returns an XDR type on success instead of a tuple, and raises on failure.
+      Like `resolve_type/1`, but returns an XDR type on success instead of a
+      tuple, and raises on failure.
       """
       @spec resolve_type!(XDR.Type.t()) :: XDR.Type.t()
       def resolve_type!(name_or_type) do
@@ -121,7 +126,8 @@ defmodule XDR.Base do
       end
 
       @doc """
-      Like `build_value/2`, but returns an XDR type on success instead of a tuple, and raises on failure.
+      Like `build_value/2`, but returns an XDR type on success instead of a
+      tuple, and raises on failure.
       See `XDR.build_value!/2` for more details.
       """
       @spec build_value!(XDR.Type.t(), any()) :: XDR.Type.t()
@@ -131,8 +137,8 @@ defmodule XDR.Base do
       end
 
       @doc """
-      To build a concrete value, supply the type or custom type name and a value appropriate
-      to that type's definition.
+      To build a concrete value, supply the type or custom type name and a value
+      appropriate to that type's definition.
       See `XDR.build_value/2` for more details.
       """
       @spec build_value(XDR.Type.t(), any()) :: {:ok, XDR.Type.t()} | {:error, any()}
@@ -188,8 +194,9 @@ defmodule XDR.Base do
 
   @doc """
   Define a named XDR type for your application by providing a name and type info.
-  Once defined in your module, you can use type type name instead of a fully built XDR type
-  in your module's functions such as `build_value/2` and `decode/1`.
+  Once defined in your module, you can use type type name instead of a fully
+  built XDR type in your module's functions such as `build_value/2` and
+  `decode/1`.
 
   The second and third arguments are the same as the first and second
   arguments of `XDR.build_type/2`.
@@ -213,7 +220,8 @@ defmodule XDR.Base do
   end
 
   @doc """
-  Convenience function to build an XDR type, allowing the use of custom defined type names.
+  Convenience function to build an XDR type, allowing the use of custom defined
+  type names.
 
   See `XDR.build_type/2`
   """

--- a/test/base_test.exs
+++ b/test/base_test.exs
@@ -1,111 +1,11 @@
-defmodule CustomXDR do
-  @moduledoc """
-  Module implementing a set of custom type defs by using XDR.Base
-  """
-  use XDR.Base
-
-  define_type("Number", Int)
-  define_type("BigFloat", Double)
-  define_type("Name", VariableOpaque, 100)
-  define_type("StringName", String, 100)
-  define_type("TheMagicNumber", Const, 42)
-
-  define_type(
-    "TestScore",
-    Struct,
-    name: "Name",
-    score: "Number",
-    grade: build_type(VariableOpaque),
-    nothing: build_type(Void)
-  )
-
-  define_type(
-    "Person",
-    Struct,
-    age: "Number",
-    name: "Name",
-    height: build_type(Float),
-    address:
-      build_type(
-        Struct,
-        nick_name: "Name",
-        street: build_type(VariableOpaque),
-        city: build_type(VariableOpaque),
-        state: build_type(Opaque, 2),
-        postal_code: build_type(VariableOpaque)
-      )
-  )
-
-  define_type(
-    "Company",
-    Struct,
-    name: "Name"
-  )
-
-  define_type(
-    "FiveNames",
-    Array,
-    type: "Name",
-    length: 5
-  )
-
-  define_type(
-    "SomeNames",
-    VariableArray,
-    type: "Name",
-    max_length: 100
-  )
-
-  define_type(
-    "AccountType",
-    Enum,
-    account_type_person: 0,
-    account_type_company: 1
-  )
-
-  define_type(
-    "AccountOwner",
-    Union,
-    switch_name: :type,
-    switch_type: "AccountType",
-    switches: [
-      account_type_person: :person,
-      account_type_company: :company
-    ],
-    arms: [
-      person: "Person",
-      company: "Company"
-    ]
-  )
-
-  define_type(
-    "AccountOwnerTwo",
-    Union,
-    switch_name: :type,
-    switch_type: build_type(Int),
-    switches: [
-      {0, :person},
-      {1, :company},
-      {2, Void}
-    ],
-    arms: [
-      person: "Person",
-      company: "Company"
-    ]
-  )
-
-  define_type(
-    "OptionalAccountOwner",
-    Optional,
-    "AccountOwner"
-  )
-end
-
 defmodule XDR.BaseTest do
   @moduledoc """
-  Tests for XDR.Base
+  Tests for `XDR.Base`. See `test/support/custom_xdr.ex` for the custom type definitions
   """
   use ExUnit.Case
+
+  # run the doctests inherited from XDR.Base
+  doctest CustomXDR
 
   @address_value [
     nick_name: "Home",

--- a/test/support/custom_xdr.ex
+++ b/test/support/custom_xdr.ex
@@ -1,0 +1,103 @@
+defmodule CustomXDR do
+  @moduledoc """
+  Module implementing a set of custom type defs by using XDR.Base
+  See `XDR.BaseTest` in `base_test.exs`
+  """
+  use XDR.Base
+
+  define_type("Number", Int)
+  define_type("BigFloat", Double)
+  define_type("Name", VariableOpaque, 100)
+  define_type("StringName", String, 100)
+  define_type("TheMagicNumber", Const, 42)
+
+  define_type(
+    "TestScore",
+    Struct,
+    name: "Name",
+    score: "Number",
+    grade: build_type(VariableOpaque),
+    nothing: build_type(Void)
+  )
+
+  define_type(
+    "Person",
+    Struct,
+    age: "Number",
+    name: "Name",
+    height: build_type(Float),
+    address:
+      build_type(
+        Struct,
+        nick_name: "Name",
+        street: build_type(VariableOpaque),
+        city: build_type(VariableOpaque),
+        state: build_type(Opaque, 2),
+        postal_code: build_type(VariableOpaque)
+      )
+  )
+
+  define_type(
+    "Company",
+    Struct,
+    name: "Name"
+  )
+
+  define_type(
+    "FiveNames",
+    Array,
+    type: "Name",
+    length: 5
+  )
+
+  define_type(
+    "SomeNames",
+    VariableArray,
+    type: "Name",
+    max_length: 100
+  )
+
+  define_type(
+    "AccountType",
+    Enum,
+    account_type_person: 0,
+    account_type_company: 1
+  )
+
+  define_type(
+    "AccountOwner",
+    Union,
+    switch_name: :type,
+    switch_type: "AccountType",
+    switches: [
+      account_type_person: :person,
+      account_type_company: :company
+    ],
+    arms: [
+      person: "Person",
+      company: "Company"
+    ]
+  )
+
+  define_type(
+    "AccountOwnerTwo",
+    Union,
+    switch_name: :type,
+    switch_type: build_type(Int),
+    switches: [
+      {0, :person},
+      {1, :company},
+      {2, Void}
+    ],
+    arms: [
+      person: "Person",
+      company: "Company"
+    ]
+  )
+
+  define_type(
+    "OptionalAccountOwner",
+    Optional,
+    "AccountOwner"
+  )
+end


### PR DESCRIPTION
Connects to #14 

- Document and spec functions defined by using XDR.Base
- Fix the XDR.Base code example in the README
- Move the custom_xdr test module to its own file